### PR TITLE
main 브랜치에 push될 때에만 workflow 실행하도록 수정

### DIFF
--- a/.github/workflows/cicd_test.yml
+++ b/.github/workflows/cicd_test.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
 
 jobs:
   build:


### PR DESCRIPTION
### Issue No.

#17 
<br/>

### 작업 내역

> 구현 사항 및 작업 내역

- [x]  main push될 때에만 workflow 실행하도록 수정


<br/>