### PR TITLE
컬렉션 조회 구현 및 앨범 조회 인가 로직 수정, request dto의 enum 필드 validation 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'io.awspring.cloud:spring-cloud-aws-s3:3.0.2'
 	implementation 'io.springfox:springfox-boot-starter:3.0.0'
 	implementation 'io.springfox:springfox-swagger-ui:3.0.0'

--- a/src/main/java/com/dearnewyear/dny/album/controller/AlbumController.java
+++ b/src/main/java/com/dearnewyear/dny/album/controller/AlbumController.java
@@ -3,11 +3,13 @@ package com.dearnewyear.dny.album.controller;
 import com.dearnewyear.dny.album.dto.AlbumInfo;
 import com.dearnewyear.dny.album.dto.request.AlbumRequest;
 import com.dearnewyear.dny.album.dto.response.AlbumResponse;
+import com.dearnewyear.dny.album.dto.response.CollectionResponse;
 import com.dearnewyear.dny.album.service.AlbumService;
 import com.dearnewyear.dny.common.error.exception.CustomException;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponses;
+import java.util.List;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -55,6 +57,22 @@ public class AlbumController {
             return ResponseEntity.ok(new AlbumResponse(albumInfo, null));
         } catch (CustomException e) {
             return ResponseEntity.status(e.getErrorCode().getStatus()).body(new AlbumResponse(null, e.getMessage()));
+        }
+    }
+
+    @ApiOperation(value = "컬렉션 조회")
+    @ApiResponses({
+            @io.swagger.annotations.ApiResponse(code = 200, message = "컬렉션 조회 성공"),
+            @io.swagger.annotations.ApiResponse(code = 400, message = "컬렉션 조회 권한 없음"),
+            @io.swagger.annotations.ApiResponse(code = 404, message = "컬렉션 조회 실패")
+    })
+    @GetMapping("/collection")
+    public ResponseEntity<CollectionResponse> viewCollection(HttpServletRequest request) {
+        try {
+            List<AlbumInfo> collection = albumService.viewCollection(request);
+            return ResponseEntity.ok(new CollectionResponse(collection, null));
+        } catch (CustomException e) {
+            return ResponseEntity.status(e.getErrorCode().getStatus()).body(new CollectionResponse(null, e.getMessage()));
         }
     }
 }

--- a/src/main/java/com/dearnewyear/dny/album/controller/AlbumController.java
+++ b/src/main/java/com/dearnewyear/dny/album/controller/AlbumController.java
@@ -32,6 +32,7 @@ public class AlbumController {
     @ApiOperation(value = "앨범 보내기")
     @ApiResponses({
             @io.swagger.annotations.ApiResponse(code = 200, message = "앨범 보내기 성공"),
+            @io.swagger.annotations.ApiResponse(code = 400, message = "앨범 보내기 권한 없거나 유효성 검사 실패"),
             @io.swagger.annotations.ApiResponse(code = 404, message = "앨범 보내기 실패")
     })
     @PostMapping("/send")

--- a/src/main/java/com/dearnewyear/dny/album/controller/AlbumController.java
+++ b/src/main/java/com/dearnewyear/dny/album/controller/AlbumController.java
@@ -33,12 +33,12 @@ public class AlbumController {
             @io.swagger.annotations.ApiResponse(code = 404, message = "앨범 보내기 실패")
     })
     @PostMapping("/send")
-    public ResponseEntity<String> sendAlbum(@ModelAttribute @Valid AlbumRequest albumRequest, HttpServletRequest request) {
+    public ResponseEntity<AlbumResponse> sendAlbum(@ModelAttribute @Valid AlbumRequest albumRequest, HttpServletRequest request) {
         try {
-            albumService.sendAlbum(albumRequest, request);
-            return ResponseEntity.ok("앨범 보내기 성공");
+            AlbumInfo albumInfo = albumService.sendAlbum(albumRequest, request);
+            return ResponseEntity.ok(new AlbumResponse(albumInfo, null));
         } catch (CustomException e) {
-            return ResponseEntity.status(e.getErrorCode().getStatus()).body(e.getMessage());
+            return ResponseEntity.status(e.getErrorCode().getStatus()).body(new AlbumResponse(null, e.getMessage()));
         }
     }
 

--- a/src/main/java/com/dearnewyear/dny/album/controller/AlbumController.java
+++ b/src/main/java/com/dearnewyear/dny/album/controller/AlbumController.java
@@ -9,6 +9,7 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponses;
 import javax.servlet.http.HttpServletRequest;
+import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -32,7 +33,7 @@ public class AlbumController {
             @io.swagger.annotations.ApiResponse(code = 404, message = "앨범 보내기 실패")
     })
     @PostMapping("/send")
-    public ResponseEntity<String> sendAlbum(@ModelAttribute AlbumRequest albumRequest, HttpServletRequest request) {
+    public ResponseEntity<String> sendAlbum(@ModelAttribute @Valid AlbumRequest albumRequest, HttpServletRequest request) {
         try {
             albumService.sendAlbum(albumRequest, request);
             return ResponseEntity.ok("앨범 보내기 성공");

--- a/src/main/java/com/dearnewyear/dny/album/domain/constant/AlbumPatterns.java
+++ b/src/main/java/com/dearnewyear/dny/album/domain/constant/AlbumPatterns.java
@@ -1,0 +1,22 @@
+package com.dearnewyear.dny.album.domain.constant;
+
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class AlbumPatterns {
+
+    public static final String ALBUM_COVER_PATTERN =
+            Stream.of(AlbumCover.values())
+                    .map(Enum::name)
+                    .collect(Collectors.joining("|"));
+
+    public static final String ALBUM_PHRASES_PATTERN =
+            Stream.of(AlbumPhrases.values())
+                    .map(Enum::name)
+                    .collect(Collectors.joining("|"));
+
+    public static final String ALBUM_BACKGROUND_PATTERN =
+            Stream.of(AlbumBackground.values())
+                    .map(Enum::name)
+                    .collect(Collectors.joining("|"));
+}

--- a/src/main/java/com/dearnewyear/dny/album/domain/constant/AlbumPatterns.java
+++ b/src/main/java/com/dearnewyear/dny/album/domain/constant/AlbumPatterns.java
@@ -1,22 +1,15 @@
 package com.dearnewyear.dny.album.domain.constant;
 
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
+import com.dearnewyear.dny.common.utils.PatternMaker;
 
 public class AlbumPatterns {
 
     public static final String ALBUM_COVER_PATTERN =
-            Stream.of(AlbumCover.values())
-                    .map(Enum::name)
-                    .collect(Collectors.joining("|"));
+            PatternMaker.makePattern(AlbumCover.class);
 
     public static final String ALBUM_PHRASES_PATTERN =
-            Stream.of(AlbumPhrases.values())
-                    .map(Enum::name)
-                    .collect(Collectors.joining("|"));
+            PatternMaker.makePattern(AlbumPhrases.class);
 
     public static final String ALBUM_BACKGROUND_PATTERN =
-            Stream.of(AlbumBackground.values())
-                    .map(Enum::name)
-                    .collect(Collectors.joining("|"));
+            PatternMaker.makePattern(AlbumBackground.class);
 }

--- a/src/main/java/com/dearnewyear/dny/album/dto/AlbumInfo.java
+++ b/src/main/java/com/dearnewyear/dny/album/dto/AlbumInfo.java
@@ -1,5 +1,6 @@
 package com.dearnewyear.dny.album.dto;
 
+import com.dearnewyear.dny.album.domain.Album;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
@@ -41,4 +42,17 @@ public class AlbumInfo {
 
     @ApiModelProperty(value = "편지 내용")
     private final String letter;
+
+    public AlbumInfo(Album album) {
+        this.albumId = album.getAlbumId();
+        this.albumCover = album.getAlbumCover().name();
+        this.albumPhrases = album.getAlbumPhrases().name();
+        this.albumBackground = album.getAlbumBackground().name();
+        this.musicName = album.getMusic().getMusicName();
+        this.musicArtist = album.getMusic().getMusicArtist();
+        this.youtubeUrlId = album.getMusic().getYoutubeUrlId();
+        this.fromName = album.getFromName();
+        this.toName = album.getToName();
+        this.letter = album.getLetter();
+    }
 }

--- a/src/main/java/com/dearnewyear/dny/album/dto/request/AlbumRequest.java
+++ b/src/main/java/com/dearnewyear/dny/album/dto/request/AlbumRequest.java
@@ -1,7 +1,12 @@
 package com.dearnewyear.dny.album.dto.request;
 
+import static com.dearnewyear.dny.album.domain.constant.AlbumPatterns.ALBUM_BACKGROUND_PATTERN;
+import static com.dearnewyear.dny.album.domain.constant.AlbumPatterns.ALBUM_COVER_PATTERN;
+import static com.dearnewyear.dny.album.domain.constant.AlbumPatterns.ALBUM_PHRASES_PATTERN;
+
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.AssertFalse;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Positive;
@@ -45,4 +50,19 @@ public class AlbumRequest {
     @NotEmpty
     @ApiModelProperty(value = "편지 내용", required = true)
     private final String letter;
+
+    @AssertFalse(message = "앨범 커버가 유효하지 않습니다.")
+    public boolean isValidAlbumCover() {
+        return ALBUM_COVER_PATTERN.matches(albumCover);
+    }
+
+    @AssertFalse(message = "앨범 문구가 유효하지 않습니다.")
+    public boolean isValidAlbumPhrases() {
+        return ALBUM_PHRASES_PATTERN.matches(albumPhrases);
+    }
+
+    @AssertFalse(message = "앨범 배경이 유효하지 않습니다.")
+    public boolean isValidAlbumBackground() {
+        return ALBUM_BACKGROUND_PATTERN.matches(albumBackground);
+    }
 }

--- a/src/main/java/com/dearnewyear/dny/album/dto/request/AlbumRequest.java
+++ b/src/main/java/com/dearnewyear/dny/album/dto/request/AlbumRequest.java
@@ -2,6 +2,9 @@ package com.dearnewyear.dny.album.dto.request;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Positive;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -10,27 +13,36 @@ import lombok.Getter;
 @ApiModel(value = "앨범 보내기 요청 모델")
 public class AlbumRequest {
 
+    @NotNull
     @ApiModelProperty(value = "앨범 커버", required = true)
     private final String albumCover;
 
+    @NotNull
     @ApiModelProperty(value = "앨범 문구", required = true)
     private final String albumPhrases;
 
+    @NotNull
     @ApiModelProperty(value = "앨범 배경", required = true)
     private final String albumBackground;
 
+    @NotNull
+    @Positive
     @ApiModelProperty(value = "음악 ID", required = true)
     private final Long musicId;
 
+    @Positive
     @ApiModelProperty(value = "받는 사람 ID")
     private final Long toUserId;
 
+    @NotEmpty
     @ApiModelProperty(value = "보내는 사람 이름", required = true)
     private final String fromName;
 
+    @NotEmpty
     @ApiModelProperty(value = "받는 사람 이름", required = true)
     private final String toName;
 
+    @NotEmpty
     @ApiModelProperty(value = "편지 내용", required = true)
     private final String letter;
 }

--- a/src/main/java/com/dearnewyear/dny/album/dto/request/AlbumRequest.java
+++ b/src/main/java/com/dearnewyear/dny/album/dto/request/AlbumRequest.java
@@ -6,7 +6,8 @@ import static com.dearnewyear.dny.album.domain.constant.AlbumPatterns.ALBUM_PHRA
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import javax.validation.constraints.AssertFalse;
+import java.util.regex.Pattern;
+import javax.validation.constraints.AssertTrue;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Positive;
@@ -51,18 +52,18 @@ public class AlbumRequest {
     @ApiModelProperty(value = "편지 내용", required = true)
     private final String letter;
 
-    @AssertFalse(message = "앨범 커버가 유효하지 않습니다.")
+    @AssertTrue(message = "앨범 커버가 유효하지 않습니다.")
     public boolean isValidAlbumCover() {
-        return ALBUM_COVER_PATTERN.matches(albumCover);
+        return Pattern.matches(ALBUM_COVER_PATTERN, albumCover);
     }
 
-    @AssertFalse(message = "앨범 문구가 유효하지 않습니다.")
+    @AssertTrue(message = "앨범 문구가 유효하지 않습니다.")
     public boolean isValidAlbumPhrases() {
-        return ALBUM_PHRASES_PATTERN.matches(albumPhrases);
+        return Pattern.matches(ALBUM_PHRASES_PATTERN, albumPhrases);
     }
 
-    @AssertFalse(message = "앨범 배경이 유효하지 않습니다.")
+    @AssertTrue(message = "앨범 배경이 유효하지 않습니다.")
     public boolean isValidAlbumBackground() {
-        return ALBUM_BACKGROUND_PATTERN.matches(albumBackground);
+        return Pattern.matches(ALBUM_BACKGROUND_PATTERN, albumBackground);
     }
 }

--- a/src/main/java/com/dearnewyear/dny/album/dto/response/CollectionResponse.java
+++ b/src/main/java/com/dearnewyear/dny/album/dto/response/CollectionResponse.java
@@ -1,0 +1,20 @@
+package com.dearnewyear.dny.album.dto.response;
+
+import com.dearnewyear.dny.album.dto.AlbumInfo;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@ApiModel
+@AllArgsConstructor
+public class CollectionResponse {
+
+    @ApiModelProperty(value = "앨범 정보 리스트")
+    private List<AlbumInfo> albumInfoList;
+
+    @ApiModelProperty(value = "에러 메시지")
+    private String errorMessage;
+}

--- a/src/main/java/com/dearnewyear/dny/album/repository/AlbumRepository.java
+++ b/src/main/java/com/dearnewyear/dny/album/repository/AlbumRepository.java
@@ -1,7 +1,11 @@
 package com.dearnewyear.dny.album.repository;
 
 import com.dearnewyear.dny.album.domain.Album;
+import com.dearnewyear.dny.user.domain.User;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AlbumRepository extends JpaRepository<Album, Long> {
+
+    List<Album> findByToUser(User user);
 }

--- a/src/main/java/com/dearnewyear/dny/album/service/AlbumService.java
+++ b/src/main/java/com/dearnewyear/dny/album/service/AlbumService.java
@@ -30,13 +30,13 @@ public class AlbumService {
     private final AlbumRepository albumRepository;
     private final MusicRepository musicRepository;
 
-    public void sendAlbum(AlbumRequest albumRequest, HttpServletRequest request) {
+    public AlbumInfo sendAlbum(AlbumRequest albumRequest, HttpServletRequest request) {
         String accessToken = jwtTokenProvider.getAccessToken(request);
         User fromUser = userRepository.findById(jwtTokenProvider.getUserId(accessToken))
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        User toUser = null;
         Long toUserId = albumRequest.getToUserId();
+        User toUser = null;
         if (toUserId != null)
             toUser = userRepository.findById(toUserId)
                     .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
@@ -56,6 +56,7 @@ public class AlbumService {
                 .letter(albumRequest.getLetter())
                 .build();
         albumRepository.save(album);
+        return new AlbumInfo(album);
     }
 
     public AlbumInfo viewAlbum(Long albumId, HttpServletRequest request) {
@@ -66,18 +67,7 @@ public class AlbumService {
         Authentication authentication = jwtTokenProvider.getAuthentication(accessToken);
         checkAlbumPermission(album, authentication);
 
-        return AlbumInfo.builder()
-                .albumId(album.getAlbumId())
-                .albumCover(String.valueOf(album.getAlbumCover()))
-                .albumPhrases(String.valueOf(album.getAlbumPhrases()))
-                .albumBackground(String.valueOf(album.getAlbumBackground()))
-                .musicName(album.getMusic().getMusicName())
-                .musicArtist(album.getMusic().getMusicArtist())
-                .youtubeUrlId(album.getMusic().getYoutubeUrlId())
-                .fromName(album.getFromName())
-                .toName(album.getToName())
-                .letter(album.getLetter())
-                .build();
+        return new AlbumInfo(album);
     }
 
     private void checkAlbumPermission(Album album, Authentication authentication) {

--- a/src/main/java/com/dearnewyear/dny/album/service/AlbumService.java
+++ b/src/main/java/com/dearnewyear/dny/album/service/AlbumService.java
@@ -82,10 +82,10 @@ public class AlbumService {
     }
 
     private boolean isFromUser(User fromUser, Authentication authentication) {
-        return fromUser.equals(authentication.getPrincipal());
+        return fromUser.getUserName().equals(authentication.getName());
     }
 
     private boolean isToUser(User toUser, Authentication authentication) {
-        return toUser.equals(authentication.getPrincipal());
+        return toUser.getUserName().equals(authentication.getName());
     }
 }

--- a/src/main/java/com/dearnewyear/dny/album/service/AlbumService.java
+++ b/src/main/java/com/dearnewyear/dny/album/service/AlbumService.java
@@ -14,6 +14,8 @@ import com.dearnewyear.dny.music.domain.Music;
 import com.dearnewyear.dny.music.repository.MusicRepository;
 import com.dearnewyear.dny.user.domain.User;
 import com.dearnewyear.dny.user.repository.UserRepository;
+import java.util.List;
+import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
@@ -68,6 +70,17 @@ public class AlbumService {
         checkAlbumPermission(album, authentication);
 
         return new AlbumInfo(album);
+    }
+
+    public List<AlbumInfo> viewCollection(HttpServletRequest request) {
+        String accessToken = jwtTokenProvider.getAccessToken(request);
+        User user = userRepository.findById(jwtTokenProvider.getUserId(accessToken))
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        List<Album> albumList = albumRepository.findByToUser(user);
+        return albumList.stream()
+                .map(AlbumInfo::new)
+                .collect(Collectors.toList());
     }
 
     private void checkAlbumPermission(Album album, Authentication authentication) {

--- a/src/main/java/com/dearnewyear/dny/common/utils/PatternMaker.java
+++ b/src/main/java/com/dearnewyear/dny/common/utils/PatternMaker.java
@@ -1,0 +1,13 @@
+package com.dearnewyear.dny.common.utils;
+
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class PatternMaker {
+
+    public static <E extends Enum<E>> String makePattern(Class<E> enumClass) {
+        return Stream.of(enumClass.getEnumConstants())
+                .map(Enum::name)
+                .collect(Collectors.joining("|"));
+    }
+}

--- a/src/main/java/com/dearnewyear/dny/music/controller/MusicController.java
+++ b/src/main/java/com/dearnewyear/dny/music/controller/MusicController.java
@@ -42,6 +42,7 @@ public class MusicController {
     @ApiOperation(value = "음악 추가")
     @ApiResponses({
             @io.swagger.annotations.ApiResponse(code = 201, message = "음악 추가 성공"),
+            @io.swagger.annotations.ApiResponse(code = 400, message = "카테고리 유효성 검사 실패"),
             @io.swagger.annotations.ApiResponse(code = 500, message = "음악 추가 실패")
     })
     @PostMapping("/add")

--- a/src/main/java/com/dearnewyear/dny/music/controller/MusicController.java
+++ b/src/main/java/com/dearnewyear/dny/music/controller/MusicController.java
@@ -7,6 +7,7 @@ import com.dearnewyear.dny.music.service.MusicService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponses;
+import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -44,7 +45,7 @@ public class MusicController {
             @io.swagger.annotations.ApiResponse(code = 500, message = "음악 추가 실패")
     })
     @PostMapping("/add")
-    public ResponseEntity<String> addMusic(@ModelAttribute AddMusicRequest addMusicRequest) {
+    public ResponseEntity<String> addMusic(@ModelAttribute @Valid AddMusicRequest addMusicRequest) {
         try {
             musicService.addMusic(addMusicRequest);
             return ResponseEntity.status(201).body("음악 추가 성공");

--- a/src/main/java/com/dearnewyear/dny/music/domain/constant/MusicPatterns.java
+++ b/src/main/java/com/dearnewyear/dny/music/domain/constant/MusicPatterns.java
@@ -1,0 +1,9 @@
+package com.dearnewyear.dny.music.domain.constant;
+
+import com.dearnewyear.dny.common.utils.PatternMaker;
+
+public class MusicPatterns {
+
+    public static String MUSIC_CATEGORY =
+            PatternMaker.makePattern(Category.class);
+}

--- a/src/main/java/com/dearnewyear/dny/music/dto/request/AddMusicRequest.java
+++ b/src/main/java/com/dearnewyear/dny/music/dto/request/AddMusicRequest.java
@@ -2,6 +2,8 @@ package com.dearnewyear.dny.music.dto.request;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -10,15 +12,19 @@ import lombok.Getter;
 @ApiModel(value = "음악 추가 요청 모델")
 public class AddMusicRequest {
 
+    @NotEmpty
     @ApiModelProperty(value = "음악 이름", required = true)
     private final String musicName;
 
+    @NotEmpty
     @ApiModelProperty(value = "아티스트", required = true)
     private final String musicArtist;
 
+    @NotEmpty
     @ApiModelProperty(value = "youtube url id", required = true)
     private final String youtubeUrlId;
 
+    @NotNull
     @ApiModelProperty(value = "카테고리", required = true)
     private final String category;
 }

--- a/src/main/java/com/dearnewyear/dny/music/dto/request/AddMusicRequest.java
+++ b/src/main/java/com/dearnewyear/dny/music/dto/request/AddMusicRequest.java
@@ -1,7 +1,11 @@
 package com.dearnewyear.dny.music.dto.request;
 
+import static com.dearnewyear.dny.music.domain.constant.MusicPatterns.MUSIC_CATEGORY;
+
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import java.util.regex.Pattern;
+import javax.validation.constraints.AssertTrue;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
@@ -27,4 +31,9 @@ public class AddMusicRequest {
     @NotNull
     @ApiModelProperty(value = "카테고리", required = true)
     private final String category;
+
+    @AssertTrue(message = "카테고리가 유효하지 않습니다.")
+    public boolean isValidCategory() {
+        return Pattern.matches(MUSIC_CATEGORY, category);
+    }
 }

--- a/src/main/java/com/dearnewyear/dny/user/controller/AuthController.java
+++ b/src/main/java/com/dearnewyear/dny/user/controller/AuthController.java
@@ -31,7 +31,7 @@ public class AuthController {
     @ApiOperation(value = "회원가입")
     @ApiResponses({
             @io.swagger.annotations.ApiResponse(code = 200, message = "회원가입 성공"),
-            @io.swagger.annotations.ApiResponse(code = 400, message = "회원가입 실패")
+            @io.swagger.annotations.ApiResponse(code = 400, message = "회원가입 실패 또는 유효성 검사 실패"),
     })
     @PostMapping("/signup")
     public ResponseEntity<AuthResponse> signup(@ModelAttribute @Valid SignupRequest request, HttpServletResponse response) {

--- a/src/main/java/com/dearnewyear/dny/user/controller/AuthController.java
+++ b/src/main/java/com/dearnewyear/dny/user/controller/AuthController.java
@@ -10,6 +10,7 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponses;
 import javax.servlet.http.HttpServletResponse;
+import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -33,7 +34,7 @@ public class AuthController {
             @io.swagger.annotations.ApiResponse(code = 400, message = "회원가입 실패")
     })
     @PostMapping("/signup")
-    public ResponseEntity<AuthResponse> signup(@ModelAttribute SignupRequest request, HttpServletResponse response) {
+    public ResponseEntity<AuthResponse> signup(@ModelAttribute @Valid SignupRequest request, HttpServletResponse response) {
         try {
             UserInfo userInfo = userService.signupAndLoginUser(request, response);
             return ResponseEntity.ok(new AuthResponse(userInfo, null));
@@ -48,7 +49,7 @@ public class AuthController {
             @io.swagger.annotations.ApiResponse(code = 404, message = "회원가입 필요")
     })
     @PostMapping("/login")
-    public ResponseEntity<AuthResponse> login(@RequestBody LoginRequest request, HttpServletResponse response) {
+    public ResponseEntity<AuthResponse> login(@RequestBody @Valid LoginRequest request, HttpServletResponse response) {
         try {
             UserInfo userInfo = userService.loginUser(request, response);
             return ResponseEntity.ok(new AuthResponse(userInfo, null));

--- a/src/main/java/com/dearnewyear/dny/user/domain/constant/UserPatterns.java
+++ b/src/main/java/com/dearnewyear/dny/user/domain/constant/UserPatterns.java
@@ -1,0 +1,12 @@
+package com.dearnewyear.dny.user.domain.constant;
+
+import com.dearnewyear.dny.common.utils.PatternMaker;
+
+public class UserPatterns {
+
+    public static final String MAIN_BACKGROUND_PATTERN =
+            PatternMaker.makePattern(MainBackground.class);
+
+    public static final String MAIN_LP_PATTERN =
+            PatternMaker.makePattern(MainLp.class);
+}

--- a/src/main/java/com/dearnewyear/dny/user/dto/request/LoginRequest.java
+++ b/src/main/java/com/dearnewyear/dny/user/dto/request/LoginRequest.java
@@ -2,6 +2,7 @@ package com.dearnewyear.dny.user.dto.request;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.Email;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,6 +13,7 @@ import lombok.NoArgsConstructor;
 @ApiModel(value = "로그인 요청 모델")
 public class LoginRequest {
 
+    @Email
     @ApiModelProperty(value = "유저 이메일", required = true)
     private String email;
 }

--- a/src/main/java/com/dearnewyear/dny/user/dto/request/SignupRequest.java
+++ b/src/main/java/com/dearnewyear/dny/user/dto/request/SignupRequest.java
@@ -1,7 +1,11 @@
 package com.dearnewyear.dny.user.dto.request;
 
+import static com.dearnewyear.dny.user.domain.constant.UserPatterns.MAIN_BACKGROUND_PATTERN;
+import static com.dearnewyear.dny.user.domain.constant.UserPatterns.MAIN_LP_PATTERN;
+
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.AssertFalse;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
@@ -28,4 +32,14 @@ public class SignupRequest {
     @NotNull
     @ApiModelProperty(value = "유저 메인 LP", required = true)
     private final String mainLp;
+
+    @AssertFalse(message = "유저 메인 배경이 유효하지 않습니다.")
+    public boolean isValidMainBackground() {
+        return MAIN_BACKGROUND_PATTERN.matches(mainBackground);
+    }
+
+    @AssertFalse(message = "유저 메인 LP가 유효하지 않습니다.")
+    public boolean isValidMainLp() {
+        return MAIN_LP_PATTERN.matches(mainLp);
+    }
 }

--- a/src/main/java/com/dearnewyear/dny/user/dto/request/SignupRequest.java
+++ b/src/main/java/com/dearnewyear/dny/user/dto/request/SignupRequest.java
@@ -5,7 +5,8 @@ import static com.dearnewyear.dny.user.domain.constant.UserPatterns.MAIN_LP_PATT
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import javax.validation.constraints.AssertFalse;
+import java.util.regex.Pattern;
+import javax.validation.constraints.AssertTrue;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
@@ -33,13 +34,13 @@ public class SignupRequest {
     @ApiModelProperty(value = "유저 메인 LP", required = true)
     private final String mainLp;
 
-    @AssertFalse(message = "유저 메인 배경이 유효하지 않습니다.")
+    @AssertTrue(message = "유저 메인 배경이 유효하지 않습니다.")
     public boolean isValidMainBackground() {
-        return MAIN_BACKGROUND_PATTERN.matches(mainBackground);
+        return Pattern.matches(MAIN_BACKGROUND_PATTERN, mainBackground);
     }
 
-    @AssertFalse(message = "유저 메인 LP가 유효하지 않습니다.")
+    @AssertTrue(message = "유저 메인 LP가 유효하지 않습니다.")
     public boolean isValidMainLp() {
-        return MAIN_LP_PATTERN.matches(mainLp);
+        return Pattern.matches(MAIN_LP_PATTERN, mainLp);
     }
 }

--- a/src/main/java/com/dearnewyear/dny/user/dto/request/SignupRequest.java
+++ b/src/main/java/com/dearnewyear/dny/user/dto/request/SignupRequest.java
@@ -2,6 +2,9 @@ package com.dearnewyear.dny.user.dto.request;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -10,15 +13,19 @@ import lombok.Getter;
 @ApiModel(value = "회원가입 요청 모델")
 public class SignupRequest {
 
+    @NotEmpty
     @ApiModelProperty(value = "유저 이름", required = true)
     private final String userName;
 
+    @Email
     @ApiModelProperty(value = "유저 이메일", required = true)
     private final String email;
 
+    @NotNull
     @ApiModelProperty(value = "유저 메인 배경", required = true)
     private final String mainBackground;
 
+    @NotNull
     @ApiModelProperty(value = "유저 메인 LP", required = true)
     private final String mainLp;
 }


### PR DESCRIPTION
### Issue No.

#12 
<br/>

### 작업 내역

> 구현 사항 및 작업 내역

- [x]  컬렉션 조회 기능 구현
- [x]  앨범 조회 시 인가 로직 수정
- [x]  request dto 바인딩 전 enum 필드에 들어갈 값이 옳은지 validation 하는 부분 추가


<br/>