### PR TITLE
다른 사용자 메인 정보 조회 구현

### DIFF
--- a/src/main/java/com/dearnewyear/dny/user/controller/AuthController.java
+++ b/src/main/java/com/dearnewyear/dny/user/controller/AuthController.java
@@ -4,7 +4,7 @@ import com.dearnewyear.dny.common.error.exception.CustomException;
 import com.dearnewyear.dny.user.dto.UserInfo;
 import com.dearnewyear.dny.user.dto.request.LoginRequest;
 import com.dearnewyear.dny.user.dto.request.SignupRequest;
-import com.dearnewyear.dny.user.dto.response.AuthResponse;
+import com.dearnewyear.dny.user.dto.response.UserInfoResponse;
 import com.dearnewyear.dny.user.service.UserService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -34,12 +34,12 @@ public class AuthController {
             @io.swagger.annotations.ApiResponse(code = 400, message = "회원가입 실패 또는 유효성 검사 실패"),
     })
     @PostMapping("/signup")
-    public ResponseEntity<AuthResponse> signup(@ModelAttribute @Valid SignupRequest request, HttpServletResponse response) {
+    public ResponseEntity<UserInfoResponse> signup(@ModelAttribute @Valid SignupRequest request, HttpServletResponse response) {
         try {
             UserInfo userInfo = userService.signupAndLoginUser(request, response);
-            return ResponseEntity.ok(new AuthResponse(userInfo, null));
+            return ResponseEntity.ok(new UserInfoResponse(userInfo, null));
         } catch (CustomException e) {
-            return ResponseEntity.status(e.getErrorCode().getStatus()).body(new AuthResponse(null, e.getMessage()));
+            return ResponseEntity.status(e.getErrorCode().getStatus()).body(new UserInfoResponse(null, e.getMessage()));
         }
     }
 
@@ -49,12 +49,12 @@ public class AuthController {
             @io.swagger.annotations.ApiResponse(code = 404, message = "회원가입 필요")
     })
     @PostMapping("/login")
-    public ResponseEntity<AuthResponse> login(@RequestBody @Valid LoginRequest request, HttpServletResponse response) {
+    public ResponseEntity<UserInfoResponse> login(@RequestBody @Valid LoginRequest request, HttpServletResponse response) {
         try {
             UserInfo userInfo = userService.loginUser(request, response);
-            return ResponseEntity.ok(new AuthResponse(userInfo, null));
+            return ResponseEntity.ok(new UserInfoResponse(userInfo, null));
         } catch (CustomException e) {
-            return ResponseEntity.status(e.getErrorCode().getStatus()).body(new AuthResponse(null, e.getMessage()));
+            return ResponseEntity.status(e.getErrorCode().getStatus()).body(new UserInfoResponse(null, e.getMessage()));
         }
     }
 

--- a/src/main/java/com/dearnewyear/dny/user/controller/UserController.java
+++ b/src/main/java/com/dearnewyear/dny/user/controller/UserController.java
@@ -1,7 +1,16 @@
 package com.dearnewyear.dny.user.controller;
 
+import com.dearnewyear.dny.common.error.exception.CustomException;
+import com.dearnewyear.dny.user.dto.UserInfo;
+import com.dearnewyear.dny.user.dto.response.UserInfoResponse;
+import com.dearnewyear.dny.user.service.UserService;
 import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponses;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -10,4 +19,22 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/user")
 public class UserController {
+
+    private final UserService userService;
+
+    @ApiOperation(value = "다른 사용자 메인 정보")
+    @ApiResponses({
+            @io.swagger.annotations.ApiResponse(code = 200, message = "메인 조회 성공"),
+            @io.swagger.annotations.ApiResponse(code = 400, message = "메인 조회 권한 없음"),
+            @io.swagger.annotations.ApiResponse(code = 404, message = "메인 조회 실패")
+    })
+    @GetMapping("/main/{userId}")
+    public ResponseEntity<UserInfoResponse> getMainInfo(@PathVariable Long userId) {
+        try {
+            UserInfo userInfo = userService.getOtherUserInfo(userId);
+            return ResponseEntity.ok(new UserInfoResponse(userInfo, null));
+        } catch (CustomException e) {
+            return ResponseEntity.status(e.getErrorCode().getStatus()).body(new UserInfoResponse(null, e.getMessage()));
+        }
+    }
 }

--- a/src/main/java/com/dearnewyear/dny/user/dto/UserInfo.java
+++ b/src/main/java/com/dearnewyear/dny/user/dto/UserInfo.java
@@ -19,7 +19,7 @@ public class UserInfo {
     @ApiModelProperty(value = "유저 닉네임")
     private final String userName;
 
-    @ApiModelProperty(value = "유저 이메일")
+    @ApiModelProperty(value = "유저 이메일, 타 유저 정보 조회 시에는 null")
     private final String email;
 
     @ApiModelProperty(value = "유저 메인 배경")

--- a/src/main/java/com/dearnewyear/dny/user/dto/response/UserInfoResponse.java
+++ b/src/main/java/com/dearnewyear/dny/user/dto/response/UserInfoResponse.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 @Getter
 @ApiModel(value = "로그인 응답 모델")
 @AllArgsConstructor
-public class AuthResponse {
+public class UserInfoResponse {
 
     @ApiModelProperty(value = "유저 정보")
     private UserInfo userInfo;

--- a/src/main/java/com/dearnewyear/dny/user/service/UserService.java
+++ b/src/main/java/com/dearnewyear/dny/user/service/UserService.java
@@ -49,6 +49,18 @@ public class UserService {
         response.setHeader("Authorization", "Bearer " + newAccessToken);
     }
 
+    public UserInfo getOtherUserInfo(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        return UserInfo.builder()
+                .userId(user.getUserId())
+                .userName(user.getUserName())
+                .mainBackground(String.valueOf(user.getMainBackground()))
+                .mainLp(String.valueOf(user.getMainLp()))
+                .playlist(getPlaylist(user))
+                .build();
+    }
+
     private UserInfo getUserInfo(HttpServletResponse response, User user) {
         String accessToken = jwtTokenProvider.createAccessToken(user);
         String refreshToken = jwtTokenProvider.createRefreshToken(user);


### PR DESCRIPTION
### Issue No.

#32 
<br/>

### 작업 내역

> 구현 사항 및 작업 내역

- [x]  response dto 이름 변경 (조금 더 범용적으로 쓰기 위해 ..,,)
- [x]  다른 사용자 정보 조회 구현: 로그인, 회원가입 시와는 다르게 email 값은 null



<br/>