### PR TITLE
Oauth 로직 일부 백엔드에서 수행하도록 되돌림

### DIFF
--- a/src/main/java/com/dearnewyear/dny/common/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/dearnewyear/dny/common/jwt/JwtTokenProvider.java
@@ -54,7 +54,6 @@ public class JwtTokenProvider {
 
         claims.put("userId", user.getUserId());
         claims.put("userName", user.getUserName());
-        claims.put("email", user.getEmail());
 
         return Jwts.builder()
                 .setClaims(claims)
@@ -79,12 +78,9 @@ public class JwtTokenProvider {
 
         Long userId = claims.get("userId", Long.class);
         String userName = claims.get("userName", String.class);
-        String email = claims.get("email", String.class);
 
         Optional<User> user = userRepository.findById(userId);
-        if (user.isPresent()
-                && userName.equals(user.get().getUserName())
-                && email.equals(user.get().getEmail())) {
+        if (user.isPresent() && userName.equals(user.get().getUserName())) {
             return createAccessToken(user.get());
         } else {
             throw new CustomException(ErrorCode.INVALID_TOKEN);

--- a/src/main/java/com/dearnewyear/dny/user/controller/AuthController.java
+++ b/src/main/java/com/dearnewyear/dny/user/controller/AuthController.java
@@ -30,14 +30,14 @@ public class AuthController {
 
     @ApiOperation(value = "회원가입")
     @ApiResponses({
-            @io.swagger.annotations.ApiResponse(code = 200, message = "회원가입 성공"),
+            @io.swagger.annotations.ApiResponse(code = 201, message = "회원가입 성공"),
             @io.swagger.annotations.ApiResponse(code = 400, message = "회원가입 실패 또는 유효성 검사 실패"),
     })
     @PostMapping("/signup")
     public ResponseEntity<UserInfoResponse> signup(@ModelAttribute @Valid SignupRequest request, HttpServletResponse response) {
         try {
             UserInfo userInfo = userService.signupAndLoginUser(request, response);
-            return ResponseEntity.ok(new UserInfoResponse(userInfo, null));
+            return ResponseEntity.status(201).body(new UserInfoResponse(userInfo, null));
         } catch (CustomException e) {
             return ResponseEntity.status(e.getErrorCode().getStatus()).body(new UserInfoResponse(null, e.getMessage()));
         }

--- a/src/main/java/com/dearnewyear/dny/user/service/KakaoOAuth2Service.java
+++ b/src/main/java/com/dearnewyear/dny/user/service/KakaoOAuth2Service.java
@@ -61,19 +61,19 @@ public class KakaoOAuth2Service {
         }
     }
 
-//    public UserInfo getKakaoUser(String token, HttpServletResponse response) {
-//        RestTemplate restTemplate = new RestTemplate();
-//        HttpHeaders headers = new HttpHeaders();
-//        headers.add("Authorization", "Bearer " + token);
-//        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
-//        ResponseEntity<Map> kakaoResponse = restTemplate.postForEntity(kakaoUserInfoUri, new HttpEntity<>(headers), Map.class);
-//
-//        if (kakaoResponse.getStatusCode() == HttpStatus.OK) {
-//            Map<String, Object> kakaoAccount = (Map<String, Object>) kakaoResponse.getBody().get("kakao_account");
-//            String email = (String) kakaoAccount.get("email");
-//            return userService.loginUser(email, response);
-//        } else {
-//            throw new CustomException(ErrorCode.KAKAO_OAUTH2_ERROR);
-//        }
-//    }
+    public UserInfo getKakaoUser(String token, HttpServletResponse response) {
+        RestTemplate restTemplate = new RestTemplate();
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "Bearer " + token);
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+        ResponseEntity<Map> kakaoResponse = restTemplate.postForEntity(kakaoUserInfoUri, new HttpEntity<>(headers), Map.class);
+
+        if (kakaoResponse.getStatusCode() == HttpStatus.OK) {
+            Map<String, Object> kakaoAccount = (Map<String, Object>) kakaoResponse.getBody().get("kakao_account");
+            String email = (String) kakaoAccount.get("email");
+            return userService.loginUser(email, response);
+        } else {
+            throw new CustomException(ErrorCode.KAKAO_OAUTH2_ERROR);
+        }
+    }
 }

--- a/src/main/java/com/dearnewyear/dny/user/service/UserService.java
+++ b/src/main/java/com/dearnewyear/dny/user/service/UserService.java
@@ -7,11 +7,11 @@ import com.dearnewyear.dny.common.error.exception.CustomException;
 import com.dearnewyear.dny.common.jwt.JwtTokenProvider;
 import com.dearnewyear.dny.user.domain.User;
 import com.dearnewyear.dny.user.dto.UserInfo;
-import com.dearnewyear.dny.user.dto.request.LoginRequest;
 import com.dearnewyear.dny.user.dto.request.SignupRequest;
 import com.dearnewyear.dny.user.repository.UserRepository;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -37,11 +37,15 @@ public class UserService {
         return getUserInfo(response, user);
     }
 
-    public UserInfo loginUser(LoginRequest request, HttpServletResponse response) {
-        String email = request.getEmail();
-        User user = userRepository.findByEmail(email)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-        return getUserInfo(response, user);
+    public UserInfo loginUser(String email, HttpServletResponse response) {
+        Optional<User> user = userRepository.findByEmail(email);
+        if (user.isPresent()) {
+            return getUserInfo(response, user.get());
+        } else {
+            return UserInfo.builder()
+                    .email(email)
+                    .build();
+        }
     }
 
     public void renewToken(String refreshToken, HttpServletResponse response) {


### PR DESCRIPTION
### Issue No.

#
<br/>

### 작업 내역

> 구현 사항 및 작업 내역

- [x]  카카오 인증 코드를 프론트에서 받아 토큰 발급 및 유저 정보 조회
- [x]  해당 유저가 dny 사용자일 시 로그인, 아니면 404 반환


<br/>